### PR TITLE
Feature/local simc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 api_secrets.py
+local_secrets.py
 output/
 profiles/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -13,13 +13,27 @@ This repo includes scripts and sims for shadow priests.
 ## How to Run
 All scripts are run built with python3, but should be able to be run with python2 (results may vary).
 
+### Prepare your environment
 1. Run `pip install -r requirements.txt` in order for the scripts to work.
 2. Edit and confirm config in `config.yml`, this controls how profiles are built, sims are ran, and aggregated. See the [wiki](https://github.com/WarcraftPriests/sl-shadow-priest/wiki/Config-File) for more information.
-3. Run `python profiles.py dir/ [--ptr, --dungeons, --talents [am, stm, hv], --covenant [kyrian, necrolord, night_fae, venthyr]]` for the directory you want to sim. Current talent options are indicated by the config keys under: `builds`. If you don't specify `talents` or `covenant` and that sim uses it based on config, all combinations will be automatically generated.
-4. To run the sim in Raidbots create `api_secrets.py` inside the root directory. Set `api_key = 'XXX'`.
-5. By default if a file already exists in `output/` or if the weight in `internal/weights.py` is 0, sim.py will skip it.
-6. To run the sims use `python sim.py dir/ [--iterations 10000, --dungeons, --talents [am, hv, stm]]` where `dir/` is the sim directory you want to sim. If you don't specify `talents` or `covenant` and that sim uses it based on config, all combinations will be automatically generated.
-7. Based on config keys in `analyze` markdown, csv, and json will be generated for the aggregated sims. These will output separate files for Composite, Single Target, or Dungeon sims. You can find all output files in the `results/` folder in any sim folder.
+
+### Create profiles
+1. Run `python profiles.py dir/ [--ptr, --dungeons, --talents [am, stm, hv], --covenant [kyrian, necrolord, night_fae, venthyr]]` for the directory you want to sim. Current talent options are indicated by the config keys under: `builds`. If you don't specify `talents` or `covenant` and that sim uses it based on config, all combinations will be automatically generated.
+
+### Simulate
+#### Use raidbots
+1. To run the sim in Raidbots create `api_secrets.py` inside the root directory. Set `api_key = 'XXX'`.
+2. By default if a file already exists in `output/` or if the weight in `internal/weights.py` is 0, sim.py will skip it.
+3. To run the sims use `python sim.py dir/ [--iterations 10000, --dungeons, --talents [am, hv, stm]]` where `dir/` is the sim directory you want to sim. If you don't specify `talents` or `covenant` and that sim uses it based on config, all combinations will be automatically generated.
+4. Based on config keys in `analyze` markdown, csv, and json will be generated for the aggregated sims. These will output separate files for Composite, Single Target, or Dungeon sims. You can find all output files in the `results/` folder in any sim folder.
+
+#### Use local simc
+1. To run with a local simc you have to options:
+1.1 use the simc you have on your Path ( nothing to setup here)
+1.2 use a simc located in a seperated folder, create a `local_secrets.py` inside the root directory and set `simc_path = 'XXX'`
+2. By default if a file already exists in `output/` or if the weight in `internal/weights.py` is 0, sim.py will skip it.
+3. To run the sims use `python sim.py dir/ [--iterations 10000, --dungeons, --talents [am, hv, stm] --local]` where `dir/` is the sim directory you want to sim. If you don't specify `talents` or `covenant` and that sim uses it based on config, all combinations will be automatically generated.
+4. Based on config keys in `analyze` markdown, csv, and json will be generated for the aggregated sims. These will output separate files for Composite, Single Target, or Dungeon sims. You can find all output files in the `results/` folder in any sim folder.
 
 ### General Order of sims to run
 The following is a rough order to follow when running sims. Generally the things on the same row can be run at the same time since they do not influence each other.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ All scripts are run built with python3, but should be able to be run with python
 #### Use local simc
 1. To run with a local simc you have to options:
 1.1 use the simc you have on your Path ( nothing to setup here)
-1.2 use a simc located in a seperated folder, create a `local_secrets.py` inside the root directory and set `simc_path = 'XXX'`
+1.2 use a simc located in a seperated folder, create a `local_secrets.py` inside the root directory and set `simc_path = '{"nightly": "path/to/exectuable", "rework": "another/path"}'`
+=> We use a dict here to support different `simcVersions` like raidbots, you can so define a different simc installation by every key you define.
+=> If you don't supply the `local_secrets.py` we will use the simc on the path for every different `simcVersion` defined in `config.yml`.
+
 2. By default if a file already exists in `output/` or if the weight in `internal/weights.py` is 0, sim.py will skip it.
 3. To run the sims use `python sim.py dir/ [--iterations 10000, --dungeons, --talents [am, hv, stm] --local]` where `dir/` is the sim directory you want to sim. If you don't specify `talents` or `covenant` and that sim uses it based on config, all combinations will be automatically generated.
 4. Based on config keys in `analyze` markdown, csv, and json will be generated for the aggregated sims. These will output separate files for Composite, Single Target, or Dungeon sims. You can find all output files in the `results/` folder in any sim folder.

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -8,9 +8,13 @@ def sim_local(simc_path, profile_location, output_location, iterations, simc_bui
     try:
         subprocess.check_call([simc_path, "json2={0}".format(output_location), "iterations={0}".format(iterations), "simcVersion={0}".format(simc_build), profile_location], stdout=output, stderr=output)
         output.close()
-        os.remove(output_location.replace("json", "log"))
     except:
-        print("{0} has an error. Skipping file (see detailed informations in {1})".format(locationList[-1], output_location.replace("json", "log")))
+        print("-- {0} has an error. Skipping file.".format(locationList[-1]))
+        with open(output_location.replace("json", "log")) as file:
+            lines = file.readlines()
+            print("-- {0}".format(lines[-1]))
+    
+    os.remove(output_location.replace("json", "log"))
 
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -2,27 +2,15 @@ import subprocess
 import os
 
 def sim_local(simc_path, profile_location, output_location):
-    resultList = output_location.split("/")
-    update_profile(profile_location, resultList[-1])
-    FNULL = open(os.devnull, 'w')
-    subprocess.check_call([simc_path, profile_location], stdout=FNULL, stderr=subprocess.STDOUT)
+    locationList = output_location.split("/")
+    output = open(output_location.replace("json", "log"), 'w')
     try:
-        os.rename(resultList[-1], output_location)
-    except FileNotFoundError:
-        print("{0} was not created (error in sim). Skipping file.".format(resultList[-1]))
+        subprocess.check_call([simc_path, "json2={0}".format(output_location), profile_location], stdout=output, stderr=output)
+        output.close()
+        os.remove(output_location.replace("json", "log"))
+    except:
+        print("{0} was not created. Skipping file (see detailed informations in {1})".format(locationList[-1], output_location.replace("json", "log")))
 
-
-def update_profile(profile_location, report_name):
-    if check_for_existing_json(profile_location, report_name):
-        with open(profile_location, 'a+') as file:
-            file.write("json2={0}\n".format(report_name))
-    
-def check_for_existing_json(profile_location, report_name):
-    with open(profile_location) as file:
-        if "json2={0}".format(report_name) in file.read():
-            return False
-        else:
-            return True
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):
     sim_local(simc_path, profile_location, output_location)

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -1,0 +1,21 @@
+import subprocess
+import os
+
+def sim_local(simc_path, profile_location, output_location):
+    resultList = output_location.split("/")
+    update_profile(profile_location, resultList[-1])
+    subprocess.run([simc_path, profile_location])
+    try:
+        os.rename(resultList[-1], output_location)
+    except FileNotFoundError:
+        print("{0} was not created (error in sim). Skipping file.".format(resultList[-1]))
+
+
+def update_profile(profile_location, report_name):
+    print(report_name)
+    with open(profile_location, "a+") as file:
+        file.write("json2={0}".format(report_name))
+        file.close()
+
+def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):
+    sim_local(simc_path, profile_location, output_location)

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -9,7 +9,7 @@ def sim_local(simc_path, profile_location, output_location):
         output.close()
         os.remove(output_location.replace("json", "log"))
     except:
-        print("{0} was not created. Skipping file (see detailed informations in {1})".format(locationList[-1], output_location.replace("json", "log")))
+        print("{0} has an error. Skipping file (see detailed informations in {1})".format(locationList[-1], output_location.replace("json", "log")))
 
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -1,11 +1,12 @@
 import subprocess
 import os
 
-def sim_local(simc_path, profile_location, output_location):
+def sim_local(simc_path, profile_location, output_location, iterations, simc_build):
     locationList = output_location.split("/")
     output = open(output_location.replace("json", "log"), 'w')
+    
     try:
-        subprocess.check_call([simc_path, "json2={0}".format(output_location), profile_location], stdout=output, stderr=output)
+        subprocess.check_call([simc_path, "json2={0}".format(output_location), "iterations={0}".format(iterations), "simcVersion={0}".format(simc_build), profile_location], stdout=output, stderr=output)
         output.close()
         os.remove(output_location.replace("json", "log"))
     except:
@@ -13,4 +14,4 @@ def sim_local(simc_path, profile_location, output_location):
 
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):
-    sim_local(simc_path, profile_location, output_location)
+    sim_local(simc_path, profile_location, output_location, iterations, simc_build)

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -1,21 +1,22 @@
 import subprocess
 import os
 
-def sim_local(simc_path, profile_location, output_location, iterations, simc_build):
+def sim_local(simc_path, profile_location, output_location, iterations):
     locationList = output_location.split("/")
     output = open(output_location.replace("json", "log"), 'w')
     
     try:
-        subprocess.check_call([simc_path, "json2={0}".format(output_location), "iterations={0}".format(iterations), "simcVersion={0}".format(simc_build), profile_location], stdout=output, stderr=output)
+        subprocess.check_call([simc_path, "json2={0}".format(output_location), "iterations={0}".format(iterations), profile_location], stdout=output, stderr=output)
         output.close()
     except:
+        output.close()
         print("-- {0} has an error. Skipping file.".format(locationList[-1]))
         with open(output_location.replace("json", "log")) as file:
             lines = file.readlines()
             print("-- {0}".format(lines[-1]))
-    
+
     os.remove(output_location.replace("json", "log"))
 
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):
-    sim_local(simc_path, profile_location, output_location, iterations, simc_build)
+    sim_local(simc_path, profile_location, output_location, iterations)

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -12,10 +12,16 @@ def sim_local(simc_path, profile_location, output_location):
 
 
 def update_profile(profile_location, report_name):
-    print(report_name)
-    with open(profile_location, "a+") as file:
-        file.write("json2={0}".format(report_name))
-        file.close()
+    if check_for_existing_json(profile_location, report_name):
+        with open(profile_location, 'a+') as file:
+            file.write("json2={0}\n".format(report_name))
+    
+def check_for_existing_json(profile_location, report_name):
+    with open(profile_location) as file:
+        if "json2={0}".format(report_name) in file.read():
+            return False
+        else:
+            return True
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):
     sim_local(simc_path, profile_location, output_location)

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -4,7 +4,8 @@ import os
 def sim_local(simc_path, profile_location, output_location):
     resultList = output_location.split("/")
     update_profile(profile_location, resultList[-1])
-    subprocess.run([simc_path, profile_location])
+    FNULL = open(os.devnull, 'w')
+    subprocess.check_call([simc_path, profile_location], stdout=FNULL, stderr=subprocess.STDOUT)
     try:
         os.rename(resultList[-1], output_location)
     except FileNotFoundError:

--- a/sim.py
+++ b/sim.py
@@ -34,7 +34,6 @@ def get_path(simcBuildVersion):
     try:
         import local_secrets
         pathDict = local_secrets.simc_path
-        print(platform.system())
         if platform.system() == 'Darwin' or platform.system() == 'Linux':
             return handle_path_darwin(pathDict[simcBuildVersion])
         else:
@@ -142,7 +141,7 @@ def main():
     parser.add_argument(
         '--covenant', help='indicate covenant build for output.', choices=config["covenants"])
     parser.add_argument(
-        '--local', help='indicate covenant build for output.', action='store_true')
+        '--local', help='indicate if the simulation should run local.', action='store_true')
     args = parser.parse_args()
 
     sys.path.insert(0, args.dir)

--- a/sim.py
+++ b/sim.py
@@ -87,9 +87,9 @@ def run_sims(args, iterations, talent, covenant):
             raidbots(api_key, profile_location,
                      config["simcBuild"], output_location, profile_name_with_dir, iterations)
         elif weight == 0:
-            print("{0} has a weight of 0. Skipping file.".format(output_name))
+            print("-- {0} has a weight of 0. Skipping file.".format(output_name))
         else:
-            print("{0} already exists. Skipping file.".format(output_name))
+            print("-- {0} already exists. Skipping file.".format(output_name))
 
 
 def convert_to_csv(args, weights, talent, covenant):

--- a/sim.py
+++ b/sim.py
@@ -45,8 +45,13 @@ def get_api_key(args):
     if args.local:
         return get_path() 
     else :
-        import api_secrets
-        return api_secrets.api_key
+        try:
+            import api_secrets
+            return api_secrets.api_key
+        except ModuleNotFoundError:
+            print('Please create api_secrets.py file like mentioned in the Readme')
+            sys.exit()
+        
 
 
 def run_sims(args, iterations, talent, covenant):


### PR DESCRIPTION
### Description of the Change

Added a possibility to use simc localy instead of raidbots. I used the approach with minimal changes to the current behavior of the python scripts. 

The profiles.py keeps unchanged so you create the same profiles for local and raidbots sims. In sim.py i introduced a new argument --local with this set he uses the logic in internal/simc.py the rest of the logic stays the same so only the import of "raidbots" and the api_key got changed.

### Benefits

Well :) we could use simc local if wanted ;)
