### PR TITLE
Run linter on Pull requests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change
just adds the pylint action to run on pull requests, not just pushes.

### Benefits
Otherwise, this would only run on pulls that originated from a branch

### Applicable Issues
N/A