### PR TITLE
filter unique trinket combos by id instead of name

### DIFF
--- a/trinket-combos/build_combos.py
+++ b/trinket-combos/build_combos.py
@@ -39,13 +39,19 @@ combos = {
 }
 
 
+def item_id(trinket):
+    """given a comma-separated definition for a trinket, returns just the id"""
+    i = trinket.split(",")[1]
+    return i[3:]
+
+
 def build_combos():
     """generates the combination list with unique equipped trinkets only"""
     trinkets = combinations(combos.keys(), 2)
     unique_trinkets = []
     for pair in trinkets:
-        # check if name matches, trinkets are unique
-        if pair[0][:-5] != pair[1][:-5]:
+        # check if item id matches, trinkets are unique
+        if item_id(combos[pair[0]]) != item_id(combos[pair[1]]):
             unique_trinkets.append(pair)
     print("Generated {0} combinations.".format(len(unique_trinkets)))
     return unique_trinkets


### PR DESCRIPTION
Trinket combinations were checked for uniqueness by looking at the
trinket's name minus the last few characters, to remove ilvl and number
of allies for Cabalist's Hymnal. Unbound Changeling and Cabalist's
Hymnal are special cases with info between name and ilvl, and while
Hymnal was being handled, Changeling was not.

Change build_combos to check for uniqueness by item id. This changes
total combinations from 384 to 372. Removed combinations are below:

Unbound_Changeling_All_236 - Unbound_Changeling_Mastery_236
Unbound_Changeling_All_236 - Unbound_Changeling_Mastery_252
Unbound_Changeling_All_252 - Unbound_Changeling_Haste_236
Unbound_Changeling_All_252 - Unbound_Changeling_Mastery_236
Unbound_Changeling_All_252 - Unbound_Changeling_Mastery_252
Unbound_Changeling_Haste_236 - Unbound_Changeling_All_236
Unbound_Changeling_Haste_236 - Unbound_Changeling_Mastery_236
Unbound_Changeling_Haste_236 - Unbound_Changeling_Mastery_252
Unbound_Changeling_Haste_252 - Unbound_Changeling_All_236
Unbound_Changeling_Haste_252 - Unbound_Changeling_All_252
Unbound_Changeling_Haste_252 - Unbound_Changeling_Mastery_236
Unbound_Changeling_Haste_252 - Unbound_Changeling_Mastery_252

-----------------------------
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

See commit message above.

### Benefits

* Fewer combinations to run should help improve update times somewhat when making changes.
* Fewer combinations can make the charts more readable.
* Filtering should now be a little more resilient to future oddballs like Changeling and Hymnal.

### Applicable Issues

none - happy to file an issue if needed
